### PR TITLE
replace yarn with pnpm

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,5 +1,7 @@
 name: check
 on: [push]
+env:
+  TEST_REPORTER: tap
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,7 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - run: nohup Xvfb &

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,5 +1,11 @@
 name: check
-on: [push]
+on:
+  push:
+    tags-ignore:
+      - '[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - '**'
+
 env:
   TEST_REPORTER: tap
 jobs:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,9 @@ permissions:
   id-token: write # Required for OIDC
   contents: read
 
+env:
+  TEST_REPORTER: tap
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,8 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - uses: actions/setup-node@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILD = build/$(PROJECT).js build/$(PROJECT)-worker.js
 DEBUG_FLAG ?= true
 
 %/node_modules: %/package.json
-	yarn --cwd $(@D) --no-progress
+	pnpm -C $(@D) install
 	touch $@
 
 .SECONDEXPANSION:
@@ -148,7 +148,7 @@ update-test-fixtures: test-integration format
 
 ALL_DEPENDENCIES = $(DEPENDENCIES) $(DEPENDENCIES_TEST) $(DEPENDENCIES_INTEGRATION)
 distclean: clean clean-test
-	rm -fr $(ALL_DEPENDENCIES) $(ALL_DEPENDENCIES:node_modules=yarn.lock)
+	rm -fr $(ALL_DEPENDENCIES) $(ALL_DEPENDENCIES:node_modules=pnpm-lock.yaml)
 
 clean:
 	rm -fr build

--- a/meta/package.json
+++ b/meta/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@biomejs/biome": "2.2.3",
+    "@biomejs/biome": "2.3.11",
     "@mapwhit/glsl-minify": "~1",
     "ejs": "^3.1.10",
     "esbuild": "^0.27.2"

--- a/meta/package.json
+++ b/meta/package.json
@@ -3,7 +3,7 @@
     "@biomejs/biome": "2.2.3",
     "@mapwhit/glsl-minify": "~1",
     "ejs": "^3.1.10",
-    "esbuild": "^0.25.9"
+    "esbuild": "^0.27.2"
   },
   "type": "module",
   "license": "BSD-3-Clause"

--- a/meta/pnpm-workspace.yaml
+++ b/meta/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild

--- a/test/README.md
+++ b/test/README.md
@@ -7,14 +7,23 @@ First you must configure your development environment per [`../CONTRIBUTING.md`]
 
 There are two test suites associated with Mapbox GL JS
 
- - `yarn test` runs quick unit tests
- - `yarn run test-suite` runs slower integration tests
+````sh
+make test # runs quick unit tests
+make test-integration # runs slower integration tests
+````
 
  To run individual tests:
 
- - Unit tests: `yarn test-unit path/to/file.test.js` where path *does not include* `test/unit/`
-   - e.g. `yarn test-unit ui/handler/scroll_zoom.test.js`
- - Render tests: `yarn test-render render-test-name` (e.g. `yarn test-render background-color/default`)
+````sh
+node --test test/unit/ui/map_tests/map_is_moving.test.js # unit test
+make test-integration TEST_FILTER=background-color/default # integration tests
+````
+
+ To display code coverage information:
+
+````sh
+make coverage
+````
 
 ## Writing Unit Tests
 

--- a/test/pnpm-workspace.yaml
+++ b/test/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - canvas
+  - gl


### PR DESCRIPTION
- **improve instructions on test running**
- **use `pnpm` instead of `yarn`**
- **upgrade `esbuild` to 0.27.2**
- **upgrade `biome` to 2.3.11**
- **use pnpm in github actions**
- **use `tap` test reporter in github actions**
- **ignore `check` action on release tag**
